### PR TITLE
fix: NVIDIA hybrid GPU live boot support and stability fixes

### DIFF
--- a/pkgbuild/mhwd-biglinux.install
+++ b/pkgbuild/mhwd-biglinux.install
@@ -1,7 +1,9 @@
 post_install() {
     systemctl enable nvidia-manager-verify
+    systemctl enable mhwd-nvidia-hybrid-live
 }
 
 pre_remove() {
     systemctl disable nvidia-manager-verify
+    systemctl disable mhwd-nvidia-hybrid-live
 }

--- a/usr/bin/biglinux-gpu-manager
+++ b/usr/bin/biglinux-gpu-manager
@@ -40,90 +40,106 @@ if echo "$devices" | grep -qiEw "VGA.*(AMD|ATI)"; then
 fi
 
 function removeModesetGrub {
-    if grep -q '.modeset=' /etc/default/grub; then
-        bbv_change_variable remove "/etc/default/grub" "GRUB_CMDLINE_LINUX_DEFAULT" "nvidia-drm.modeset"
-        bbv_change_variable remove "/etc/default/grub" "GRUB_CMDLINE_LINUX_DEFAULT" "i915.modeset"
-        bbv_change_variable remove "/etc/default/grub" "GRUB_CMDLINE_LINUX_DEFAULT" "nouveau.modeset"
-        bbv_change_variable remove "/etc/default/grub" "GRUB_CMDLINE_LINUX_DEFAULT" "radeon.modeset"
-        bbv_change_variable remove "/etc/default/grub" "GRUB_CMDLINE_LINUX_DEFAULT" "amdgpu.modeset"
+    if [[ -f /etc/default/grub ]] && grep -q '.modeset=' /etc/default/grub; then
+        sed -i 's/ *nvidia-drm\.modeset=[0-9]*//g' /etc/default/grub
+        sed -i 's/ *i915\.modeset=[0-9]*//g' /etc/default/grub
+        sed -i 's/ *nouveau\.modeset=[0-9]*//g' /etc/default/grub
+        sed -i 's/ *radeon\.modeset=[0-9]*//g' /etc/default/grub
+        sed -i 's/ *amdgpu\.modeset=[0-9]*//g' /etc/default/grub
         updateGrub=true
         echo 'Remove modeset in grub'
     fi
 }
 
 function addBlacklistNouveauGrub {
+    if [[ ! -f /etc/default/grub ]]; then
+        return
+    fi
     if ! grep -q 'rd.driver.blacklist=nouveau' /etc/default/grub; then
-        bbv_change_variable add "/etc/default/grub" "GRUB_CMDLINE_LINUX_DEFAULT" "rd.driver.blacklist=nouveau"
+        sed -i 's/\(GRUB_CMDLINE_LINUX_DEFAULT="[^"]*\)/\1 rd.driver.blacklist=nouveau/' /etc/default/grub
         updateGrub=true
     fi
     if ! grep -q 'modprobe.blacklist=nouveau' /etc/default/grub; then
-        bbv_change_variable add "/etc/default/grub" "GRUB_CMDLINE_LINUX_DEFAULT" "modprobe.blacklist=nouveau"
+        sed -i 's/\(GRUB_CMDLINE_LINUX_DEFAULT="[^"]*\)/\1 modprobe.blacklist=nouveau/' /etc/default/grub
         updateGrub=true
     fi
 }
 
 function removeBlacklistNouveauGrub {
-
+    if [[ ! -f /etc/default/grub ]]; then
+        return
+    fi
     if grep -q 'rd.driver.blacklist=nouveau' /etc/default/grub; then
-        bbv_change_variable remove "/etc/default/grub" "GRUB_CMDLINE_LINUX_DEFAULT" "rd.driver.blacklist=nouveau"
+        sed -i 's/ *rd\.driver\.blacklist=nouveau//g' /etc/default/grub
         updateGrub=true
     fi
-    if ! grep -q 'modprobe.blacklist=nouveau' /etc/default/grub; then
-        bbv_change_variable remove "/etc/default/grub" "GRUB_CMDLINE_LINUX_DEFAULT" "modprobe.blacklist=nouveau"
+    if grep -q 'modprobe.blacklist=nouveau' /etc/default/grub; then
+        sed -i 's/ *modprobe\.blacklist=nouveau//g' /etc/default/grub
         updateGrub=true
     fi
 }
 
 function useIntelDriverInXorgForIntel {
-    if grep -q 'Driver "modesetting"' /usr/share/X11/xorg.conf.d/10-intel-nvidia-drm-outputclass.conf; then
-        sed -i 's|Driver "modesetting"|Driver "intel"|g' /usr/share/X11/xorg.conf.d/10-intel-nvidia-drm-outputclass.conf
+    local xorg_conf="/usr/share/X11/xorg.conf.d/10-intel-nvidia-drm-outputclass.conf"
+    if [[ -f "$xorg_conf" ]] && grep -q 'Driver "modesetting"' "$xorg_conf"; then
+        sed -i 's|Driver "modesetting"|Driver "intel"|g' "$xorg_conf"
     fi
 }
 
 function useModesettingDriverInXorgForIntel {
-    if grep -q 'Driver "intel"' /usr/share/X11/xorg.conf.d/10-intel-nvidia-drm-outputclass.conf; then
-        sed -i 's|Driver "intel"|Driver "modesetting"|g' /usr/share/X11/xorg.conf.d/10-intel-nvidia-drm-outputclass.conf
+    local xorg_conf="/usr/share/X11/xorg.conf.d/10-intel-nvidia-drm-outputclass.conf"
+    if [[ -f "$xorg_conf" ]] && grep -q 'Driver "intel"' "$xorg_conf"; then
+        sed -i 's|Driver "intel"|Driver "modesetting"|g' "$xorg_conf"
     fi
 }
 
 function initcpioEnableModesetNvidia {
-    if grep -q 'options *nvidia-drm *modeset=' /etc/modprobe.d/nvidia.conf; then
-        if grep '.*#.*options *nvidia-drm modeset=' /etc/modprobe.d/nvidia.conf; then
-            echo 'options nvidia-drm modeset=1' >> /etc/modprobe.d/nvidia.conf
+    local nvidia_conf="/etc/modprobe.d/nvidia.conf"
+    if [[ -f "$nvidia_conf" ]] && grep -q 'options *nvidia-drm *modeset=' "$nvidia_conf"; then
+        if grep -q '.*#.*options *nvidia-drm modeset=' "$nvidia_conf"; then
+            echo 'options nvidia-drm modeset=1' >> "$nvidia_conf"
         else
-            sed -i 's|nvidia-drm *modeset=[01]|nvidia-drm modeset=1|g' /etc/modprobe.d/nvidia.conf
+            sed -i 's|nvidia-drm *modeset=[01]|nvidia-drm modeset=1|g' "$nvidia_conf"
         fi
     else
-        echo 'options nvidia-drm modeset=1' >> /etc/modprobe.d/nvidia.conf
+        mkdir -p /etc/modprobe.d
+        echo 'options nvidia-drm modeset=1' >> "$nvidia_conf"
     fi
 }
 
 function initcpioDisableModesetNvidia {
-    if grep -q 'options *nvidia-drm *modeset=' /etc/modprobe.d/nvidia.conf; then
-        if grep '.*#.*options *nvidia-drm modeset=' /etc/modprobe.d/nvidia.conf; then
-            echo 'options nvidia-drm modeset=0' >> /etc/modprobe.d/nvidia.conf
+    local nvidia_conf="/etc/modprobe.d/nvidia.conf"
+    if [[ -f "$nvidia_conf" ]] && grep -q 'options *nvidia-drm *modeset=' "$nvidia_conf"; then
+        if grep -q '.*#.*options *nvidia-drm modeset=' "$nvidia_conf"; then
+            echo 'options nvidia-drm modeset=0' >> "$nvidia_conf"
         else
-            sed -i 's|nvidia-drm *modeset=[01]|nvidia-drm modeset=0|g' /etc/modprobe.d/nvidia.conf
+            sed -i 's|nvidia-drm *modeset=[01]|nvidia-drm modeset=0|g' "$nvidia_conf"
         fi
     else
-        echo 'options nvidia-drm modeset=0' >> /etc/modprobe.d/nvidia.conf
+        mkdir -p /etc/modprobe.d
+        echo 'options nvidia-drm modeset=0' >> "$nvidia_conf"
     fi
 }
 
 function initcpioEnablePageAttributeTable {
-    if grep -q 'options NVreg_UsePageAttributeTable=' /etc/modprobe.d/nvidia.conf; then
-        if grep '.*#.*options *NVreg_UsePageAttributeTable=' /etc/modprobe.d/nvidia.conf; then
-            echo 'options nvidia NVreg_UsePageAttributeTable=1 NVreg_InitializeSystemMemoryAllocations=0' >> /etc/modprobe.d/nvidia.conf
+    local nvidia_conf="/etc/modprobe.d/nvidia.conf"
+    mkdir -p /etc/modprobe.d
+    if [[ -f "$nvidia_conf" ]] && grep -q 'options NVreg_UsePageAttributeTable=' "$nvidia_conf"; then
+        if grep -q '.*#.*options *NVreg_UsePageAttributeTable=' "$nvidia_conf"; then
+            echo 'options nvidia NVreg_UsePageAttributeTable=1 NVreg_InitializeSystemMemoryAllocations=0' >> "$nvidia_conf"
         else
-            sed -i 's|NVreg_UsePageAttributeTable=[01]|NVreg_UsePageAttributeTable=1|g;s|NVreg_InitializeSystemMemoryAllocations=[01]|NVreg_InitializeSystemMemoryAllocations=0|g' /etc/modprobe.d/nvidia.conf
+            sed -i 's|NVreg_UsePageAttributeTable=[01]|NVreg_UsePageAttributeTable=1|g;s|NVreg_InitializeSystemMemoryAllocations=[01]|NVreg_InitializeSystemMemoryAllocations=0|g' "$nvidia_conf"
         fi
     else
-        echo 'options nvidia NVreg_UsePageAttributeTable=1 NVreg_InitializeSystemMemoryAllocations=0' >> /etc/modprobe.d/nvidia.conf
+        echo 'options nvidia NVreg_UsePageAttributeTable=1 NVreg_InitializeSystemMemoryAllocations=0' >> "$nvidia_conf"
     fi
 }
 
 function initcpioRemovePageAttributeTable {
-    sed 's|.*options nvidia NVreg_UsePageAttributeTable=[01] NVreg_InitializeSystemMemoryAllocations=[01].*||g' /etc/modprobe.d/nvidia.conf
+    local nvidia_conf="/etc/modprobe.d/nvidia.conf"
+    if [[ -f "$nvidia_conf" ]]; then
+        sed -i 's|.*options nvidia NVreg_UsePageAttributeTable=[01] NVreg_InitializeSystemMemoryAllocations=[01].*||g' "$nvidia_conf"
+    fi
 }
 
 function enableSwitcheroo {
@@ -136,24 +152,52 @@ function enableSwitcheroo {
 }
 
 function autoInstallDriver {
-    mhwd -a pci nonfree 0300
+    if command -v mhwd >/dev/null 2>&1; then
+        mhwd -a pci nonfree 0300 || echo 'mhwd auto-install failed' >&2
+    else
+        echo 'mhwd not available' >&2
+    fi
 }
 
-function addInSddm {
-xrandrNvidiaId=$(xrandr --listproviders | grep -i nvidia | sed -r 's/.*providers: ([0-9]*) .*/\1/')
-if [[ $xrandrNvidiaId = 1 ]]; then
-    xrandrIntelId=0
-elif [[ $xrandrNvidiaId = 0 ]]; then
-    xrandrIntelId=1
-fi
+function addInDisplayManager {
+    # Get xrandr provider IDs (may fail if no display is available)
+    local xrandrNvidiaId
+    xrandrNvidiaId=$(xrandr --listproviders 2>/dev/null | grep -i nvidia | sed -r 's/.*providers: ([0-9]*) .*/\1/' || true)
 
-if [[ "$useGpu" = "Intel" ]]; then
-    commandToAddInSddm=$(echo "xrandr --setprovideroutputsource $xrandrIntelId $xrandrNvidiaId")
-elif [[ "$useGpu" = "Nvidia" ]]; then
-    commandToAddInSddm=$(echo "xrandr --setprovideroutputsource $xrandrNvidiaId $xrandrIntelId")
-fi
-    sed -i 's|.*xrandr *--setprovideroutputsource.*||g' /usr/share/sddm/scripts/Xsetup
-    echo "$commandToAddInSddm" >> /usr/share/sddm/scripts/Xsetup
+    if [[ -z "$xrandrNvidiaId" ]]; then
+        echo 'xrandr providers not available (no display), skipping DM configuration' >&2
+        return
+    fi
+
+    local xrandrIntelId
+    if [[ "$xrandrNvidiaId" = 1 ]]; then
+        xrandrIntelId=0
+    elif [[ "$xrandrNvidiaId" = 0 ]]; then
+        xrandrIntelId=1
+    else
+        return
+    fi
+
+    local commandToAdd
+    if [[ "$useGpu" = "Intel" ]]; then
+        commandToAdd="xrandr --setprovideroutputsource $xrandrIntelId $xrandrNvidiaId"
+    elif [[ "$useGpu" = "Nvidia" ]]; then
+        commandToAdd="xrandr --setprovideroutputsource $xrandrNvidiaId $xrandrIntelId"
+    fi
+
+    # SDDM
+    if [[ -f /usr/share/sddm/scripts/Xsetup ]]; then
+        sed -i 's|.*xrandr *--setprovideroutputsource.*||g' /usr/share/sddm/scripts/Xsetup
+        echo "$commandToAdd" >> /usr/share/sddm/scripts/Xsetup
+    fi
+
+    # LightDM
+    if [[ -f /etc/lightdm/lightdm.conf ]]; then
+        mkdir -p /etc/lightdm
+        echo "#!/bin/bash" > /etc/lightdm/display_setup.sh
+        echo "$commandToAdd" >> /etc/lightdm/display_setup.sh
+        chmod +x /etc/lightdm/display_setup.sh
+    fi
 }
 
 function installIntelXorgPkg {
@@ -176,7 +220,7 @@ if [[ $gpuIntel && $gpuNvidia && -z $biglinuxGpuMode || $gpuIntel && $gpuNvidia 
     addBlacklistNouveauGrub
     useIntelDriverInXorgForIntel
     enableSwitcheroo
-    useGpu=Intel addInSddm
+    useGpu=Intel addInDisplayManager
     if $updateGrub; then
         update-grub
     fi
@@ -195,7 +239,7 @@ elif [[ $gpuIntel && $gpuNvidia && "$1" = "mode-2" ]]; then
     addBlacklistNouveauGrub
     useIntelDriverInXorgForIntel
     enableSwitcheroo
-    useGpu=Intel addInSddm
+    useGpu=Intel addInDisplayManager
     if $updateGrub; then
         update-grub
     fi
@@ -213,7 +257,7 @@ elif [[ $gpuIntel && $gpuNvidia && "$1" = "mode-3" ]]; then
     addBlacklistNouveauGrub
     useModesettingDriverInXorgForIntel
     enableSwitcheroo
-    useGpu=Intel addInSddm
+    useGpu=Intel addInDisplayManager
     if $updateGrub; then
         update-grub
     fi
@@ -231,7 +275,7 @@ elif [[ $gpuIntel && $gpuNvidia && "$1" = "mode-4" ]]; then
     addBlacklistNouveauGrub
     useModesettingDriverInXorgForIntel
     enableSwitcheroo
-    useGpu=Intel addInSddm
+    useGpu=Intel addInDisplayManager
     if $updateGrub; then
         update-grub
     fi
@@ -249,7 +293,7 @@ elif [[ $gpuIntel && $gpuNvidia && "$1" = "mode-5" ]]; then
     addBlacklistNouveauGrub
     useModesettingDriverInXorgForIntel
     enableSwitcheroo
-    useGpu=Intel addInSddm
+    useGpu=Intel addInDisplayManager
     if $updateGrub; then
         update-grub
     fi
@@ -267,7 +311,7 @@ elif [[ $gpuIntel && $gpuNvidia && "$1" = "mode-6" ]]; then
     addBlacklistNouveauGrub
     useModesettingDriverInXorgForIntel
     enableSwitcheroo
-    useGpu=Intel addInSddm
+    useGpu=Intel addInDisplayManager
     if $updateGrub; then
         update-grub
     fi
@@ -286,7 +330,7 @@ elif [[ $gpuIntel && $gpuNvidia && "$1" = "mode-7" ]]; then
     installIntelXorgPkg
     useIntelDriverInXorgForIntel
     enableSwitcheroo
-    useGpu=Intel addInSddm
+    useGpu=Intel addInDisplayManager
     if $updateGrub; then
         update-grub
     fi
@@ -305,7 +349,7 @@ elif [[ $gpuIntel && $gpuNvidia && "$1" = "mode-8" ]]; then
     installIntelXorgPkg
     useIntelDriverInXorgForIntel
     enableSwitcheroo
-    useGpu=Intel addInSddm
+    useGpu=Intel addInDisplayManager
     if $updateGrub; then
         update-grub
     fi
@@ -329,7 +373,7 @@ elif [[ $gpuIntel && $gpuNvidia && "$1" = "mode-9" ]]; then
     addBlacklistNouveauGrub
     useIntelDriverInXorgForIntel
     enableSwitcheroo
-    useGpu=Nvidia addInSddm
+    useGpu=Nvidia addInDisplayManager
     if $updateGrub; then
         update-grub
     fi
@@ -348,7 +392,7 @@ elif [[ $gpuIntel && $gpuNvidia && "$1" = "mode-10" ]]; then
     addBlacklistNouveauGrub
     useIntelDriverInXorgForIntel
     enableSwitcheroo
-    useGpu=Nvidia addInSddm
+    useGpu=Nvidia addInDisplayManager
     if $updateGrub; then
         update-grub
     fi
@@ -366,7 +410,7 @@ elif [[ $gpuIntel && $gpuNvidia && "$1" = "mode-11" ]]; then
     addBlacklistNouveauGrub
     useModesettingDriverInXorgForIntel
     enableSwitcheroo
-    useGpu=Nvidia addInSddm
+    useGpu=Nvidia addInDisplayManager
     if $updateGrub; then
         update-grub
     fi
@@ -384,7 +428,7 @@ elif [[ $gpuIntel && $gpuNvidia && "$1" = "mode-12" ]]; then
     addBlacklistNouveauGrub
     useModesettingDriverInXorgForIntel
     enableSwitcheroo
-    useGpu=Nvidia addInSddm
+    useGpu=Nvidia addInDisplayManager
     if $updateGrub; then
         update-grub
     fi
@@ -402,7 +446,7 @@ elif [[ $gpuIntel && $gpuNvidia && "$1" = "mode-13" ]]; then
     addBlacklistNouveauGrub
     useModesettingDriverInXorgForIntel
     enableSwitcheroo
-    useGpu=Nvidia addInSddm
+    useGpu=Nvidia addInDisplayManager
     if $updateGrub; then
         update-grub
     fi
@@ -420,7 +464,7 @@ elif [[ $gpuIntel && $gpuNvidia && "$1" = "mode-14" ]]; then
     addBlacklistNouveauGrub
     useModesettingDriverInXorgForIntel
     enableSwitcheroo
-    useGpu=Nvidia addInSddm
+    useGpu=Nvidia addInDisplayManager
     if $updateGrub; then
         update-grub
     fi
@@ -439,7 +483,7 @@ elif [[ $gpuIntel && $gpuNvidia && "$1" = "mode-15" ]]; then
     installIntelXorgPkg
     useIntelDriverInXorgForIntel
     enableSwitcheroo
-    useGpu=Nvidia addInSddm
+    useGpu=Nvidia addInDisplayManager
     if $updateGrub; then
         update-grub
     fi
@@ -458,7 +502,7 @@ elif [[ $gpuIntel && $gpuNvidia && "$1" = "mode-16" ]]; then
     installIntelXorgPkg
     useIntelDriverInXorgForIntel
     enableSwitcheroo
-    useGpu=Nvidia addInSddm
+    useGpu=Nvidia addInDisplayManager
     if $updateGrub; then
         update-grub
     fi

--- a/usr/bin/mhwd-nvidia-hybrid-live
+++ b/usr/bin/mhwd-nvidia-hybrid-live
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+#-------------------------------------------------------------------------------
+# mhwd-nvidia-hybrid-live
+# Configure NVIDIA hybrid GPU (Intel/NVIDIA) in live boot environment
+# Part of mhwd-biglinux package
+#-------------------------------------------------------------------------------
+
+LOG_TAG="mhwd-nvidia-hybrid-live"
+
+log_info() {
+    echo "${LOG_TAG}: $1"
+}
+
+log_error() {
+    echo "${LOG_TAG}: ERROR: $1" >&2
+}
+
+# Only run in live mode
+if [[ ! -e /livefs-pkgs.txt ]]; then
+    log_info "Not in live mode, exiting"
+    exit 0
+fi
+
+# Detect GPUs
+vga_list=$(lspci 2>/dev/null | grep -iE "VGA|3D|Display" || true)
+
+has_intel=false
+has_nvidia=false
+
+if echo "$vga_list" | grep -qi intel; then
+    has_intel=true
+fi
+
+if echo "$vga_list" | grep -qi nvidia; then
+    has_nvidia=true
+fi
+
+# Only proceed for hybrid Intel/NVIDIA systems
+if ! $has_intel || ! $has_nvidia; then
+    log_info "Not a hybrid Intel/NVIDIA system, exiting"
+    exit 0
+fi
+
+log_info "Hybrid Intel/NVIDIA GPU detected"
+log_info "Intel: $(echo "$vga_list" | grep -i intel)"
+log_info "NVIDIA: $(echo "$vga_list" | grep -i nvidia)"
+
+# Check if nvidia module is already loaded
+if lsmod | grep -q '^nvidia '; then
+    log_info "NVIDIA module already loaded, skipping installation"
+else
+    # Install hybrid driver via mhwd if available
+    if command -v mhwd >/dev/null 2>&1; then
+        # Check if a hybrid intel-nvidia configuration is available
+        if mhwd -la 2>/dev/null | grep -q 'hybrid-intel-nvidia.*prime'; then
+            log_info "Installing NVIDIA hybrid driver via mhwd"
+            if mhwd -a pci nonfree 0300 2>&1; then
+                log_info "NVIDIA hybrid driver installed successfully via mhwd"
+            else
+                log_error "mhwd auto-install failed, trying manual modprobe"
+                modprobe nvidia-drm 2>/dev/null || true
+                modprobe nvidia-modeset 2>/dev/null || true
+                modprobe nvidia-uvm 2>/dev/null || true
+            fi
+        else
+            log_info "No hybrid-intel-nvidia-prime config available in mhwd"
+            modprobe nvidia-drm 2>/dev/null || true
+        fi
+    else
+        log_info "mhwd not available, trying manual modprobe"
+        modprobe nvidia-drm 2>/dev/null || true
+    fi
+fi
+
+# Ensure modprobe configuration exists
+if [[ ! -f /etc/modprobe.d/nvidia.conf ]]; then
+    echo "options nvidia-drm modeset=1" > /etc/modprobe.d/nvidia.conf
+    log_info "Created /etc/modprobe.d/nvidia.conf with modeset=1"
+fi
+
+# Fix DRI device permissions for live session
+if [[ -e /dev/dri/renderD128 ]]; then
+    chmod 666 /dev/dri/renderD* 2>/dev/null || true
+    log_info "Fixed DRI device permissions"
+fi
+
+# Enable and start switcheroo-control
+if command -v switcherooctl >/dev/null 2>&1 || [[ -f /usr/lib/systemd/system/switcheroo-control.service ]]; then
+    if ! systemctl -q is-active switcheroo-control 2>/dev/null; then
+        systemctl enable --now switcheroo-control 2>/dev/null || true
+        log_info "switcheroo-control enabled and started"
+    fi
+fi
+
+# Create drirc for performance
+if [[ ! -f /etc/drirc ]]; then
+    cat > /etc/drirc <<'DRIRC'
+<device screen="0" driver="dri2">
+    <application name="Default">
+        <option name="vblank_mode" value="0"/>
+    </application>
+</device>
+DRIRC
+    log_info "Created /etc/drirc"
+fi
+
+# Verify result
+if lsmod | grep -q '^nvidia '; then
+    log_info "SUCCESS: NVIDIA module is loaded"
+    if command -v nvidia-smi >/dev/null 2>&1; then
+        log_info "nvidia-smi available: $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || echo 'query failed')"
+    fi
+else
+    log_info "WARNING: NVIDIA module could not be loaded. System will use nouveau/modesetting"
+fi
+
+exit 0

--- a/usr/bin/mhwd-verify-hybrid-boot
+++ b/usr/bin/mhwd-verify-hybrid-boot
@@ -1,61 +1,47 @@
 #!/usr/bin/env bash
 
 #-------------------------------------------------------------------------------
-# Fix video device permission in live mode, added in 2026/01/28 to fix nvidia proprietary driver
+# mhwd-verify-hybrid-boot
+# Verify and configure hybrid GPU setup during boot
+# Part of mhwd-biglinux package
 #-------------------------------------------------------------------------------
-if [ -e "/livefs-pkgs.txt" ]; then
-	sudo chmod 666 /dev/dri/renderD*
+
+# Fix video device permission in live mode
+if [[ -e /livefs-pkgs.txt ]]; then
+	chmod 666 /dev/dri/renderD* 2>/dev/null || true
 fi
 
-# verify if switcheroo is enabled
-if ! systemctl -q is-enabled switcheroo-control; then
-	vgaList=$(lspci | grep -iE "VGA|3D|Display")
-	if [[ $(echo $vgaList | grep -i nvidia) ]] && [[ $(echo "$vgaList" | wc -l) > 1 ]]; then
-		if grep 'bignvidia=1' /proc/cmdline; then
-			biglinux-gpu-manager mode-1
-		elif  grep 'bignvidia=2' /proc/cmdline; then
-			biglinux-gpu-manager mode-2
-		elif  grep 'bignvidia=3' /proc/cmdline; then
-			biglinux-gpu-manager mode-3
-		elif  grep 'bignvidia=4' /proc/cmdline; then
-			biglinux-gpu-manager mode-4
-		elif  grep 'bignvidia=5' /proc/cmdline; then
-			biglinux-gpu-manager mode-5
-		elif  grep 'bignvidia=6' /proc/cmdline; then
-			biglinux-gpu-manager mode-6
-		elif  grep 'bignvidia=7' /proc/cmdline; then
-			biglinux-gpu-manager mode-7
-		elif  grep 'bignvidia=8' /proc/cmdline; then
-			biglinux-gpu-manager mode-8
-		elif  grep 'bignvidia=9' /proc/cmdline; then
-			biglinux-gpu-manager mode-9
-		elif  grep 'bignvidia=10' /proc/cmdline; then
-			biglinux-gpu-manager mode-10
-		elif  grep 'bignvidia=11' /proc/cmdline; then
-			biglinux-gpu-manager mode-11
-		elif  grep 'bignvidia=12' /proc/cmdline; then
-			biglinux-gpu-manager mode-12
-		elif  grep 'bignvidia=13' /proc/cmdline; then
-			biglinux-gpu-manager mode-13
-		elif  grep 'bignvidia=14' /proc/cmdline; then
-			biglinux-gpu-manager mode-14
-		elif  grep 'bignvidia=15' /proc/cmdline; then
-			biglinux-gpu-manager mode-15
-		elif  grep 'bignvidia=16' /proc/cmdline; then
-			biglinux-gpu-manager mode-16
+# Verify if switcheroo is enabled
+if ! systemctl -q is-enabled switcheroo-control 2>/dev/null; then
+	vgaList=$(lspci 2>/dev/null | grep -iE "VGA|3D|Display" || true)
+	vgaCount=$(echo "$vgaList" | wc -l)
+
+	if echo "$vgaList" | grep -qi nvidia && [[ "$vgaCount" -gt 1 ]]; then
+		# Parse bignvidia= mode from kernel cmdline
+		bignvidia_mode=""
+		if grep -qoP 'bignvidia=\K[0-9]+' /proc/cmdline 2>/dev/null; then
+			bignvidia_mode=$(grep -oP 'bignvidia=\K[0-9]+' /proc/cmdline)
+		fi
+
+		if [[ -n "$bignvidia_mode" ]] && [[ "$bignvidia_mode" -ge 1 ]] && [[ "$bignvidia_mode" -le 16 ]]; then
+			biglinux-gpu-manager "mode-${bignvidia_mode}"
 		else
 			biglinux-gpu-manager
 		fi
 
-	systemctl enable --now switcheroo-control
-	echo '<device screen="0" driver="dri2">
+		systemctl enable --now switcheroo-control 2>/dev/null || true
+
+		if [[ ! -f /etc/drirc ]]; then
+			cat > /etc/drirc <<'DRIRC'
+<device screen="0" driver="dri2">
 	<application name="Default">
 		<option name="vblank_mode" value="0"/>
 	</application>
-	</device>' > /etc/drirc
-	
-# 	elif grep -Eiq '(VGA|3d).*(radeon|amd|ati)' <(lspci); then
-	elif [[ $(echo $vgaList | grep -Ei '(VGA|3D|Display).*(radeon|amd|ati)') ]] && [[ $(echo "$vgaList" | wc -l) > 1 ]]; then
-		systemctl enable --now switcheroo-control
+</device>
+DRIRC
+		fi
+
+	elif echo "$vgaList" | grep -Eiq '(VGA|3D|Display).*(radeon|amd|ati)' && [[ "$vgaCount" -gt 1 ]]; then
+		systemctl enable --now switcheroo-control 2>/dev/null || true
 	fi
 fi

--- a/usr/lib/systemd/system/mhwd-nvidia-hybrid-live.service
+++ b/usr/lib/systemd/system/mhwd-nvidia-hybrid-live.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Configure NVIDIA Hybrid GPU in Live Mode
+ConditionPathExists=/livefs-pkgs.txt
+Before=display-manager.service gdm.service sddm.service lightdm.service
+After=systemd-modules-load.service systemd-udevd.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/mhwd-nvidia-hybrid-live
+
+[Install]
+WantedBy=graphical.target


### PR DESCRIPTION
New files:
- mhwd-nvidia-hybrid-live: auto-detect and install NVIDIA hybrid driver on live boot via mhwd, with modprobe fallback, DRI permissions fix, switcheroo activation, and drirc creation
- mhwd-nvidia-hybrid-live.service: systemd unit that runs before display-manager, gated by ConditionPathExists=/livefs-pkgs.txt

Fixes in biglinux-gpu-manager:
- Replace all bbv_change_variable calls with direct sed commands (bbv_change_variable binary does not exist)
- Rename addInSddm to addInDisplayManager with support for SDDM, LightDM, and graceful skip when no display is available
- Add file existence guards before sed/grep on optional config files (grub, nvidia.conf, xorg conf, sddm Xsetup)
- Add mkdir -p /etc/modprobe.d before writing nvidia.conf
- Add mhwd availability check in autoInstallDriver

Fixes in mhwd-verify-hybrid-boot:
- Replace 16-branch elif/grep chain with single grep -oP parser
- Add error handling and guards on all system calls
- Remove unnecessary sudo call

Updated mhwd-biglinux.install:
- Enable/disable mhwd-nvidia-hybrid-live.service on install/remove